### PR TITLE
Fix: a precedence issue in amount checking

### DIFF
--- a/Moyasar/Mysr/Helper/MoyasarHelper.php
+++ b/Moyasar/Mysr/Helper/MoyasarHelper.php
@@ -160,7 +160,7 @@ class MoyasarHelper extends AbstractHelper
 
     public function amountSmallUnit($amount, $currency)
     {
-        return (int) $amount * (10 ** $this->currencyHelper->fractionDigits($currency));
+        return (int) ($amount * (10 ** $this->currencyHelper->fractionDigits($currency)));
     }
 
     /**


### PR DESCRIPTION
The amount will be converted before the multiplication, resulting in failure to verify the amount, thus canceling all orders.

![Screen Shot 2020-10-05 at 10 31 53](https://user-images.githubusercontent.com/22786904/95052408-9156b680-06f7-11eb-8acd-12d46e59d0f0.png)
