### PR TITLE
Use RequireJs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ merchant_id.key
 merchant_id.cer
 merchant_id.pem
 merchant_id.csr
+
+modman

--- a/Moyasar/Mysr/view/frontend/layout/checkout_index_index.xml
+++ b/Moyasar/Mysr/view/frontend/layout/checkout_index_index.xml
@@ -3,7 +3,6 @@
 	<head>
 		<css src="Moyasar_Mysr/css/applepay.css" rel="stylesheet" type="text/css" />
 		<css src="Moyasar_Mysr/css/stc-pay.css" rel="stylesheet" type="text/css" />
-		<script src="Moyasar_Mysr/js/applepay-wrapper.js" />
 	</head>
 	<body>
 		<referenceBlock name="checkout.root">


### PR DESCRIPTION
A suggested solution to fix the exception:

`Magento\\Framework\\View\\Asset\\File\\NotFoundException(code: 0): Unable to get content for 'frontend/Mgs/baytonia/ar_SA/Moyasar_Mysr/js/applepay-wrapper.min.js' at /home/baytonia/public_html/vendor/magento/framework/View/Asset/File.php:187)"} []`


- Undertest