### PR TITLE
Exclude order payment table columns from check pending orders query

### DIFF
--- a/Schedule/CheckPending.php
+++ b/Schedule/CheckPending.php
@@ -155,7 +155,7 @@ class CheckPending
     {
         $query = $this->orderCollection
             ->getSelect()
-            ->join(['pp' => 'sales_order_payment'], 'main_table.entity_id = pp.parent_id')
+            ->join(['pp' => 'sales_order_payment'], 'main_table.entity_id = pp.parent_id', [])
             ->where('updated_at >= ?', $this->date()->sub(DateInterval::createFromDateString('360 hour'))->format('Y-m-d H:i:s'))
             ->where('updated_at <= ?', $this->date()->sub(DateInterval::createFromDateString('5 minutes'))->format('Y-m-d H:i:s'))
             ->where('main_table.state in (?)', ['new', 'pending_payment'])


### PR DESCRIPTION
* Order collection joins order payment table with all columns which are not needed.
* When rest of the code tries to load to order by entity_id, because of there are 2 entity_id columns in order collection (1 is for order, 1 is for payment) code tries to load the order by entity_id of payment table which is wrong.
* If we do not select any columns in order collection while joining the payment table, there will be only 1 entity_id which belongs to order entity