### PR TITLE
Fix(SDK-136): stop 3D Secure / OTP modal getting stuck on loading (release 5.2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.2.5 - 2026-08-05
+
+### Fixed
+
+- Fixed credit card 3D Secure / OTP modal getting stuck on a loading state. The full-screen loader is now stopped when the OTP modal opens, and completion is detected via the iframe `load` event instead of polling the iframe URL, which also stops the cross-origin `SecurityError` console spam.
+
 ## 5.2.4 - 2026-04-05
 
 ### Fixed

--- a/Helper/MoyasarHelper.php
+++ b/Helper/MoyasarHelper.php
@@ -21,7 +21,7 @@ use Psr\Log\LoggerInterface;
 
 class MoyasarHelper extends AbstractHelper
 {
-    const VERSION = '5.2.4';
+    const VERSION = '5.2.5';
 
     const XML_PATH_CREDIT_CARD_IS_ACTIVE = 'payment/moyasar_payments/active';
     const XML_PATH_APPLE_PAY_IS_ACTIVE = 'payment/moyasar_payments_apple_pay/active';

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "moyasar-fintech/magento2",
     "description": "Magento 2 payment module that integrate with https:\\\\moyasar.com Gateway",
     "type": "magento2-module",
-    "version": "5.2.4",
+    "version": "5.2.5",
     "authors": [
         {
             "email": "support@moyasar.com",

--- a/view/frontend/web/js/view/payment/method-renderer/moyasar_payments.js
+++ b/view/frontend/web/js/view/payment/method-renderer/moyasar_payments.js
@@ -293,42 +293,56 @@ define(
             /**
              * Open IFrame with Native JS Modal
              */
-             openIframeCustom: function (link, callback) {
+            openIframeCustom: function (link, callback) {
                 const modal = document.getElementById('mysr-3d-secure-popup');
                 const iframe = document.getElementById('mysr-3d-secure-iframe');
-                let interval;
-                // Show modal
-                modal.style.display = 'flex';
-                iframe.src = link;
+                let completed = false;
 
+                // Stop the full-screen loader started in placeOrder so the OTP
+                // page is visible and interactive inside the modal.
+                fullScreenLoader.stopLoader();
 
-                // Listen for iframe location change
-                interval = setInterval(function () {
-                    try {
-                        const location = iframe.contentWindow.location;
-                        const href = location.href;
-                        if (href && href.includes('payment')) {
-                            clearInterval(interval);
-                            closeModal();
-                            if (typeof callback === 'function') callback();
-                        }
-                    } catch (e) {
-                        console.error('[Moysar] Error accessing iframe content:', e);
-                    }
-                }, 50);
-
-                function closeModal() {
+                function finish() {
+                    if (completed) return;
+                    completed = true;
+                    iframe.removeEventListener('load', onIframeLoad);
                     modal.style.display = 'none';
                     iframe.src = 'about:blank';
-                    clearInterval(interval);
                     if (typeof callback === 'function') callback();
                 }
 
+                // The iframe navigates through the bank's cross-origin ACS/OTP
+                // pages before landing back on our same-origin callback URL
+                // (which contains "payment"). Reading location.href throws a
+                // SecurityError while cross-origin, so we only attempt the read
+                // once per navigation (on the load event) and swallow the
+                // expected cross-origin error silently instead of polling every
+                // 50ms and flooding the console.
+                function onIframeLoad() {
+                    if (completed) return;
+                    try {
+                        const href = iframe.contentWindow.location.href;
+                        if (href && href.includes('payment')) {
+                            finish();
+                        }
+                    } catch (e) {
+                        // Expected while the iframe is on a cross-origin
+                        // ACS/OTP page. Nothing to do until it returns to our
+                        // same-origin callback page.
+                    }
+                }
 
-                modal.onclick = function(e) {
-                    if (e.target === modal) closeModal();
+                iframe.addEventListener('load', onIframeLoad);
+
+                // Clicking the backdrop cancels the modal; the validate
+                // controller resolves the real payment status server-side.
+                modal.onclick = function (e) {
+                    if (e.target === modal) finish();
                 };
 
+                // Show modal and load the 3D Secure / OTP page.
+                modal.style.display = 'flex';
+                iframe.src = link;
             },
             /**
              * Start the payment process.


### PR DESCRIPTION
## Description
The credit-card 3D Secure / OTP modal could spin on a loading state forever and flood the console with cross-origin SecurityError logs. Two root causes: (1) the full-screen loader started in `placeOrder` was never stopped when the OTP modal opened, so a spinner sat on top of the OTP iframe; (2) completion was detected by polling `iframe.contentWindow.location.href` every 50ms, which throws a SecurityError on every tick while the iframe is on the bank's cross-origin ACS/OTP page and only ever resolved if the iframe happened to land back same-origin.

The fix stops the full-screen loader when the modal opens and replaces the 50ms poll with a single `load`-event handler that reads the iframe URL only once per navigation (swallowing the expected cross-origin error silently). A `completed` guard ensures the callback fires exactly once, also fixing a latent double-callback bug in the old success path. Bundled as release 5.2.5 (version bumped in `composer.json`, `MoyasarHelper::VERSION`, and `CHANGELOG.md`).

## Ticket #:
https://moyasar-team.atlassian.net/browse/SDK-136

## How to test
1. Configure the Moyasar credit-card method with a 3DS-enabled key.
2. Place an order and pay with a card that triggers 3D Secure / OTP.
3. Confirm the OTP modal appears WITHOUT a full-screen spinner over it and the OTP field is interactive.
4. Complete the OTP → modal closes and you are redirected to the validate/success page exactly once.
5. Open DevTools console → confirm no repeating "[Moysar] Error accessing iframe content" SecurityError spam during the OTP step.
6. Re-open the flow and click the modal backdrop → modal cancels cleanly.

## Deployment Notes
Front-end JS change — run `setup:static-content:deploy` (and flush the full-page / JS-minify caches) after deploy so `moyasar_payments.min.js` is rebuilt. No DB migration or config changes. `etc/module.xml` setup_version intentionally unchanged.

## Suggested Plan for Review:
1. `view/frontend/web/js/view/payment/method-renderer/moyasar_payments.js` — core fix: `openIframeCustom` now stops the loader, uses the iframe `load` event instead of the 50ms poll, and guards the callback with `completed`.
2. `CHANGELOG.md` — 5.2.5 release notes (2026-08-05).
3. `composer.json` — version 5.2.4 → 5.2.5.
4. `Helper/MoyasarHelper.php` — `VERSION` constant 5.2.4 → 5.2.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
